### PR TITLE
Fix for erroneous merge commit 0f99abb

### DIFF
--- a/GetCytoMCP.m
+++ b/GetCytoMCP.m
@@ -91,7 +91,7 @@ if ~exist([ProcPath,filesep,Prefix,filesep,'CytoImages.mat'])
             %this to account for the fact that we now have blank images at the
             %beginning and end of the stack
             
-            for j=2:3%ZSlices-1
+            for j=2:ZSlices-1
                 %I need to do this because the naming convention can be
                 %different when I have only one channel.
 %                 if NChannels>1


### PR DESCRIPTION
By mistake, merge commit 0f99abb lost all commits between Feb 8th and Feb 23th, by creating an incomplete merge. This should restore repo history, by removing the following commits (which include reverts now unnecessary):

- 730c445 Revert "Merge branch 'master' of https://github.com/GarciaLab/mRNADynamics"
- 86c7f96 Revert "new classifier"
- 0f99abb Merge branch 'master' of https://github.com/GarciaLab/mRNADynamics
- 559f8ce improved clasiffiers
- 13630d2 new classifier

On top of this, changes on 13630d2 and 559f8ce should be properly merged and re-applied.