### PR TITLE
extracted filemode detection from ExportDataForFISH

### DIFF
--- a/DetermineFileMode.m
+++ b/DetermineFileMode.m
@@ -1,7 +1,7 @@
 %Determine whether we're dealing with 2-photon data from Princeton or LSM
 %data. 2-photon data uses TIF files. In LSM mode multiple files will be
 %combined into one.
-function [D, FileMode] = DetermineFileMode()
+function [D, FileMode] = DetermineFileMode(Folder)
     DTIF=dir([Folder,filesep,'*.tif']);
     DLSM=dir([Folder,filesep,'*.lsm']);     %Zeiss confocal, old LSM format
     DLIF=dir([Folder,filesep,'*.lif']);     %Leica confocal

--- a/ExportDataForFISH.m
+++ b/ExportDataForFISH.m
@@ -60,7 +60,7 @@ end
     Folder, Prefix, ExperimentType, Channel1, Channel2,OutputFolder, Channel3...
     ] = readMovieDatabase(PrefixOverrideFlag);
 
-[D, FileMode] = DetermineFileMode();
+[D, FileMode] = DetermineFileMode(Folder);
 
 %Create the output folder
 OutputFolder=[PreProcPath,filesep,Prefix];


### PR DESCRIPTION
Did some copy/paste on purpose to decouple filemode detection from actual processing (so there would be no references to variables DXXX (such as DLAT, for example). It's better to decouple this thant to couple it because we reuse DXXX vars.