### PR TITLE
LIFExport bug fixes

### DIFF
--- a/LIFExport/processLIFChannel.m
+++ b/LIFExport/processLIFChannel.m
@@ -1,4 +1,4 @@
-function processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel)
+function processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel)
   experimentType1 = (strcmpi(ExperimentType,'1spot') || strcmp(ExperimentType,'2spot') || strcmp(ExperimentType,'2spot1color')) && channelIndex == coatChannel;
   experimentType2 = strcmpi(ExperimentType,'2spot2color') || strcmpi(ExperimentType, 'inputoutput');
   experimentType3 = strcmpi(ExperimentType, 'input') && sum(channelIndex == inputProteinChannel);

--- a/LIFExport/processLIFExportMode.m
+++ b/LIFExport/processLIFExportMode.m
@@ -29,7 +29,7 @@ function FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, Pro
   for seriesIndex = 1:NSeries
     waitbar(seriesIndex/NSeries, waitbarFigure)
     for framesIndex = 1:NFrames(seriesIndex) 
-      processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel);
+      processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel);
       numberOfFrames = numberOfFrames + 1;
     end
   end

--- a/LIFExport/processLIFFrame.m
+++ b/LIFExport/processLIFFrame.m
@@ -1,6 +1,6 @@
-function processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel)
+function processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel)
   for channelIndex = 1:NChannels
-    processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel);
+    processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel);
   end
   %Now copy nuclear tracking images
   if fiducialChannel

--- a/getDropboxFolderFromMovieDatabaseContents.m
+++ b/getDropboxFolderFromMovieDatabaseContents.m
@@ -7,6 +7,12 @@ function [dropboxFolderName, rowIndex] = getDropboxFolderFromMovieDatabaseConten
   dropboxFolderColumnIndex = findColumnIndex(movieDatabaseHeaderRow, 'DropboxFolder');
   
   namestart = find(isletter(prefix));
+  if (isempty(namestart))
+    % If the prefix name does not contain any letters, defaults to 12 
+    % which is the usual size after the date.
+    namestart = 12;
+  end;
+  
   namestart = namestart(1); %Index of first letter in prefix name, i.e. start of dataset name
   
   dash_indices = find(prefix(1:namestart)=='-'); %Get indices of dashes before the start of prefix name


### PR DESCRIPTION
- Fixed bug caused by not passing inputProteinChannel as argument after functions refactor.
- Fixed bug caused by recent changes in master when trying to parse the date out of the prefix.