### PR TITLE
Modified ExportDataForFISH to delete all TIF files (except one) fromt he source folder

### DIFF
--- a/src/ExportDataForFISH.m
+++ b/src/ExportDataForFISH.m
@@ -17,13 +17,17 @@
 %                   of the middle slices (11-16) to prevent bright
 %                   reflections from overpowering the signal
 % 'PreferredFileForTest': AR 8/30/2018 don't know. 
-% 'skipframes': AR 8/30/2018 don't know. 
+% 'skipframes': AR 8/30/2018 don't know.
+% 'keepTifs': MPF 9/12/2018 Do not delete source folder TIF files when
+% running. This is used for testing purposes.
 %
 %
 % OUTPUT
 % Exported tif images are placed in the PreProcessedData folder and divided
 % into a nuclear channel for tracking/protein quantification and a channel
 % for transcriptional loci. 
+% All TIFs from source folder are deleted except argument 'keepTifs' is
+% used.
 %
 % Author (contact): Hernan Garcia
 % Created: 01/01/2016
@@ -50,7 +54,7 @@
 
 function Prefix = ExportDataForFISH(varargin)
 
-[Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest] = exportDataForFISH_processInputParameters(varargin{:})
+[Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest, keepTifs] = exportDataForFISH_processInputParameters(varargin{:})
 
 [SourcePath,FISHPath,DropboxFolder,MS2CodePath, PreProcPath,...
     Folder, Prefix, ExperimentType, Channel1, Channel2,OutputFolder, Channel3...
@@ -87,7 +91,8 @@ elseif strcmpi(FileMode,'LSM')
   FrameInfo = processZeissConfocalLSMData(Folder, D, FrameInfo, ExperimentType, Channel1, Channel2, Prefix, OutputFolder);
 
 elseif strcmpi(FileMode,'LIFExport')
-  FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, ProjectionType, Channel1, Channel2, Channel3, Prefix, OutputFolder, PreferredFileNameForTest);        
+  FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, ProjectionType, Channel1, Channel2, Channel3, Prefix,...
+   OutputFolder, PreferredFileNameForTest, keepTifs);        
 
 elseif strcmpi(FileMode,'DSPIN') || strcmpi(FileMode,'DND2')
   %Nikon spinning disk confocal mode - TH/CS 2017

--- a/src/LIFExport/processLIFExportMode.m
+++ b/src/LIFExport/processLIFExportMode.m
@@ -1,5 +1,5 @@
 % Added PreferredFileName so we can automate testing and bypass the user prompt when there are many files available.
-function FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, ProjectionType, Channel1, Channel2, Channel3, Prefix, OutputFolder, PreferredFileNameForTest)
+function FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, ProjectionType, Channel1, Channel2, Channel3, Prefix, OutputFolder, PreferredFileNameForTest, keepTifs)
   %Loads file and metadata
   [XMLFolder, SeriesFiles, SeriesFiles3] = getSeriesFiles(Folder);
   [~, ~, LIFImages, LIFMeta] = loadLIFFile(Folder);
@@ -33,5 +33,27 @@ function FrameInfo = processLIFExportMode(Folder, ExperimentType, FrameInfo, Pro
       numberOfFrames = numberOfFrames + 1;
     end
   end
+
+  if ~keepTifs
+    removeUnwantedTIFs(Folder);
+  end
+
   close(waitbarFigure)
+end
+
+% Removes all TIF files from the original folder in RawDynamicsData
+function removeUnwantedTIFs(Folder) 
+  cd(Folder);
+  tifs = dir('*.tif');
+
+  allTifs = {tifs.name};
+
+  if numel(allTifs) > 1
+    disp(['Removing TIF files from source folder ', Folder]);
+    for i = 2:numel(allTifs)
+      disp(['Deleting ', allTifs{i}]);
+      delete(allTifs{i});
+    end
+  end
+
 end

--- a/src/exportDataForFISH_processInputParameters.m
+++ b/src/exportDataForFISH_processInputParameters.m
@@ -1,4 +1,4 @@
-function [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest] = exportDataForFISH_processInputParameters(varargin)
+function [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest, keepTifs] = exportDataForFISH_processInputParameters(varargin)
   %Look at parameters
   SkipFrames = [];
   Prefix = '';
@@ -7,6 +7,7 @@ function [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest] = export
   ProjectionType = 'maxprojection'; 
   %Added new argument to specify a preferred file name and enable automatic testing
   PreferredFileNameForTest = '';
+  keepTifs = false;
   
   k=1;
   while k<=length(varargin)
@@ -21,6 +22,8 @@ function [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest] = export
     elseif isobject(varargin{k}) && isa(varargin{k}, 'PreferredFileForTest')
       PreferredFileForTest = varargin{k};
       PreferredFileNameForTest = PreferredFileForTest.fileName;
+    elseif strcmpi(varargin{k}, 'keepTifs')
+      keepTifs = true;
     else
       Prefix = varargin{k};
     end

--- a/test/testExportDataForFISH/testExportDataForFISH.m
+++ b/test/testExportDataForFISH/testExportDataForFISH.m
@@ -18,9 +18,9 @@ function testCase = testExportDataForFISH(testCase)
   deleteDirectory(preprocessedDataFolder);
 
   if (~isprop(testCase, 'PreferredFileName')) 
-    ExportDataForFISH(testCase.Prefix);
+    ExportDataForFISH(testCase.Prefix, 'keepTifs');
   else 
-    ExportDataForFISH(testCase.Prefix, testCase.PreferredFileName);
+    ExportDataForFISH(testCase.Prefix, testCase.PreferredFileName, 'keepTifs');
   end
 
   compareExpectedDataDir(testCase, preprocessedDataFolder, expectedDataFolder);

--- a/test/testSegmentSpots/testSegmentSpots.m
+++ b/test/testSegmentSpots/testSegmentSpots.m
@@ -19,8 +19,8 @@ function testCase = testSegmentSpots(testCase)
   deleteDirectory(dynamicResultsExperimentPath);
   deleteDirectory(processedDataExperimentPath);
 
-  % Precondition - Run ExportsDataForFISH
-  ExportDataForFISH(testCase.Prefix);
+  % Precondition - Run ExportsDataForFISH without deleting TIFs
+  ExportDataForFISH(testCase.Prefix, 'keepTifs');
   
   % Tests first pass
   % Generates DoGs


### PR DESCRIPTION
Also added a parameter called 'keepTifs' to allow disabling this new feature, mostly so test cases will not delete source data every time. Updated test cases to include this parameter.