### PR TITLE
Fixed test case for ExportDataForFISH to verify FrameInfo. 

### DIFF
--- a/test/testExportDataForFISH/generateExpectedExportData.m
+++ b/test/testExportDataForFISH/generateExpectedExportData.m
@@ -10,6 +10,7 @@ function generateExpectedExportData(testCase)
 
   configValues = csv2cell(CONFIG_CSV_PATH, 'fromfile');
 
+  dynamicsResultsPath = getConfigValue(configValues, 'DropboxFolder');
   PreProcPath = getConfigValue(configValues, 'PreProcPath');
   testPath = getConfigValue(configValues, 'TestPath');
   
@@ -18,12 +19,22 @@ function generateExpectedExportData(testCase)
   end
 
   %Get file names to compare in preprocessed data folder
+  experimentTestRootPath = strcat(testPath, filesep, 'ExportDataForFISH', filesep);
+
   preprocessedDataFolder = strcat(PreProcPath, filesep, testCase.Prefix);
-  expectedDataFolder = strcat(testPath, filesep, 'ExportDataForFISH', filesep, testCase.Prefix);
+  expectedPreProcFolder = strcat(experimentTestRootPath, 'PreProcessedData', filesep, testCase.Prefix);
+  
+  dynamicsResultsDataFolder = strcat(dynamicsResultsPath, filesep, testCase.Prefix);
+  expectedDynamicsResultsFolder = strcat(experimentTestRootPath, 'DynamicsResults', filesep, testCase.Prefix);
 
   deleteDirectory(preprocessedDataFolder, testCase.Prefix);
-  deleteDirectory(expectedDataFolder, testCase.Prefix);
-  mkdir(expectedDataFolder);
+  deleteDirectory(expectedPreProcFolder, testCase.Prefix);
+  
+  deleteDirectory(dynamicsResultsDataFolder, testCase.Prefix);
+  deleteDirectory(expectedDynamicsResultsFolder, testCase.Prefix);
+
+  mkdir(expectedPreProcFolder);
+  mkdir(expectedDynamicsResultsFolder);
 
   if (~isprop(testCase, 'PreferredFileName'))
     ExportDataForFISH(testCase.Prefix, 'keepTifs');
@@ -33,7 +44,9 @@ function generateExpectedExportData(testCase)
   end
 
   disp(['Copying expected data for Prefix ', testCase.Prefix]);
-  copyfile([preprocessedDataFolder, filesep, '*'], expectedDataFolder);
-  disp(['Expected data copied to folder ', expectedDataFolder]);
-  
+  copyfile([dynamicsResultsDataFolder, filesep, '*'], expectedDynamicsResultsFolder);
+  disp(['Expected data copied to folder ', expectedDynamicsResultsFolder]);
+  copyfile([preprocessedDataFolder, filesep, '*'], expectedPreProcFolder);
+  disp(['Expected data copied to folder ', expectedPreProcFolder]);
+
 end

--- a/test/testExportDataForFISH/testExportDataForFISH.m
+++ b/test/testExportDataForFISH/testExportDataForFISH.m
@@ -8,14 +8,19 @@ function testCase = testExportDataForFISH(testCase)
   
   configValues = csv2cell(CONFIG_CSV_PATH, 'fromfile');
   
+  dynamicsResultsPath = getConfigValue(configValues, 'DropboxFolder');
   PreProcPath = getConfigValue(configValues, 'PreProcPath');
   testPath = getConfigValue(configValues, 'TestPath');
   
   %Get file names to compare in preprocessed data folder
   preprocessedDataFolder = strcat(PreProcPath, filesep, testCase.Prefix);
-  expectedDataFolder = strcat(testPath, filesep, 'ExportDataForFISH', filesep, testCase.Prefix);
-
+  expectedPreProcFolder = strcat(testPath, filesep, 'ExportDataForFISH', filesep, 'PreProcessedData', filesep,...
+    testCase.Prefix);
+  
+  dynamicsResultsDataFolder = strcat(dynamicsResultsPath, filesep, testCase.Prefix);
+  
   deleteDirectory(preprocessedDataFolder, testCase.Prefix);
+  deleteDirectory(dynamicsResultsDataFolder, testCase.Prefix);
 
   if (~isprop(testCase, 'PreferredFileName')) 
     ExportDataForFISH(testCase.Prefix, 'keepTifs');
@@ -23,7 +28,8 @@ function testCase = testExportDataForFISH(testCase)
     ExportDataForFISH(testCase.Prefix, testCase.PreferredFileName, 'keepTifs');
   end
 
-  compareExpectedDataDir(testCase, preprocessedDataFolder, expectedDataFolder);
+  assertFrameInfoEqualToExpected(testCase, dynamicsResultsDataFolder, testPath, 'ExportDataForFish');
+  compareExpectedDataDir(testCase, preprocessedDataFolder, expectedPreProcFolder);
 
   elapsedTime = toc;
   fprintf('Test run for %s ended successfully at %s\n', testCase.Prefix, datestr(now,'yyyy-mm-dd HH:MM:SS.FFF'));

--- a/test/testSegmentSpots/testSegmentSpots.m
+++ b/test/testSegmentSpots/testSegmentSpots.m
@@ -28,7 +28,6 @@ function testCase = testSegmentSpots(testCase)
   
   % Then verifies log.mat and FrameInfo.mat and expected contents of dogs folder
   assertLogFileExists(testCase, dynamicResultsExperimentPath);
-  assertFrameInfoEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, 'SegmentSpots_1stPass');
   assertDogsFolderEqualToExpected(testCase, processedDataExperimentPath, testPath, 'SegmentSpots_1stPass');
 
   % Tests second pass
@@ -36,7 +35,6 @@ function testCase = testSegmentSpots(testCase)
   segmentSpots(testCase.Prefix, testCase.DoG);
 
   assertLogFileExists(testCase, dynamicResultsExperimentPath);
-  assertFrameInfoEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, 'SegmentSpots_2ndPass');
   assertDogsFolderEqualToExpected(testCase, processedDataExperimentPath, testPath, 'SegmentSpots_2ndPass');
   assertSpotsEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, 'SegmentSpots_2ndPass');
 

--- a/test/testSegmentSpotsML/testSegmentSpotsML.m
+++ b/test/testSegmentSpotsML/testSegmentSpotsML.m
@@ -36,7 +36,6 @@ function testCase = testSegmentSpotsML(testCase)
   % Then verifies FrameInfo.mat and expected contents of dogs folder
   expectedPathSubFolderFilter = ['SegmentSpotsML', filesep, 'FilterMovie'];
 
-  assertFrameInfoEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, expectedPathSubFolderFilter);
   assertDogsFolderEqualToExpected(testCase, processedDataExperimentPath, testPath, expectedPathSubFolderFilter);
   
   % Tests second pass
@@ -46,7 +45,6 @@ function testCase = testSegmentSpotsML(testCase)
   expectedPathSubfolderSpots = ['SegmentSpotsML', filesep, 'SegmentSpotsML'];
 
   assertLogFileExists(testCase, dynamicResultsExperimentPath);
-  assertFrameInfoEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, expectedPathSubfolderSpots);
   assertDogsFolderEqualToExpected(testCase, processedDataExperimentPath, testPath, expectedPathSubfolderSpots);
   assertSpotsEqualToExpected(testCase, dynamicResultsExperimentPath, testPath, expectedPathSubfolderSpots);
 


### PR DESCRIPTION
Had to restructure folders as well, and update the data generation script.

This is because, by mistake, the assertion for FrameInfo was on the segment spots test cases, but it's actually created on ExportDataForFISH.