### PR TITLE
Restructured generate data scripts

### DIFF
--- a/test/generateData/generateDataExport_2016_11_13_Hb_P2P_MS2V5_NB_MCP_mCherry.m
+++ b/test/generateData/generateDataExport_2016_11_13_Hb_P2P_MS2V5_NB_MCP_mCherry.m
@@ -1,0 +1,2 @@
+exportTest = testExport_2016_11_13_Hb_P2P_MS2V5_NB_MCP_mCherry;
+generateExpectedExportData(exportTest);

--- a/test/generateData/generateDataExport_2017_10_13_20170921_4.m
+++ b/test/generateData/generateDataExport_2017_10_13_20170921_4.m
@@ -1,0 +1,2 @@
+exportTest = testExport_2017_10_13_20170921_4;
+generateExpectedExportData(exportTest);

--- a/test/generateData/generateDataExport_2018_06_05_A140P_MSE_30uW_550V.m
+++ b/test/generateData/generateDataExport_2018_06_05_A140P_MSE_30uW_550V.m
@@ -1,0 +1,2 @@
+exportTest = testExport_2018_06_05_A140P_MSE_30uW_550V;
+generateExpectedExportData(exportTest);

--- a/test/generateData/generateDataForPrefix_2015_07_25_P2P_75uW_bi_short.m
+++ b/test/generateData/generateDataForPrefix_2015_07_25_P2P_75uW_bi_short.m
@@ -1,0 +1,4 @@
+exportTest = testExport_2015_07_25_P2P_75uW_bi_short;
+segmentSpotsMLTest = testSegmentSpotsML_2015_07_25_P2P_75uW_bi_short;
+trackmRNADynamicsTestCase = testTrackmRNADynamics_2015_07_25_P2P_75uW_bi_short;
+generateExpectedDataForPrefix(exportTest, segmentSpotsMLTest, trackmRNADynamicsTestCase);

--- a/test/generateData/generateDataSegmentSpots_2015_07_25_P2P_75uW_bi_short.m
+++ b/test/generateData/generateDataSegmentSpots_2015_07_25_P2P_75uW_bi_short.m
@@ -1,0 +1,3 @@
+% Segment spots only has one test so far
+segmentSpotsTest = testSegmentSpots_2015_07_25_P2P_75uW_bi_short;
+generateExpectedDataSegmentSpots(segmentSpotsTest);

--- a/test/generateData/generateDataTrackmRNANotHistone_2015_07_25_P2P_75uW_bi_short.m
+++ b/test/generateData/generateDataTrackmRNANotHistone_2015_07_25_P2P_75uW_bi_short.m
@@ -1,0 +1,3 @@
+% No histone path of traackmRNADynamics is processed separately
+trackmRNADynamicsNotHistoneTestCase = testTrackmRNADynamicsNotHistone_2015_07_25_P2P_75uW_bi_short;
+generateExpectedDataTrackmRNADynamicsNotHistone(trackmRNADynamicsNotHistoneTestCase);

--- a/test/regenerateExpectedData.m
+++ b/test/regenerateExpectedData.m
@@ -1,11 +1,11 @@
-exportTest = testExport_2015_07_25_P2P_75uW_bi_short;
-segmentSpotsMLTest = testSegmentSpotsML_2015_07_25_P2P_75uW_bi_short;
-trackmRNADynamicsTestCase = testTrackmRNADynamics_2015_07_25_P2P_75uW_bi_short;
-generateExpectedDataForPrefix(exportTest, segmentSpotsMLTest, trackmRNADynamicsTestCase);
+%exportTest = testExport_2015_07_25_P2P_75uW_bi_short;
+%segmentSpotsMLTest = testSegmentSpotsML_2015_07_25_P2P_75uW_bi_short;
+%trackmRNADynamicsTestCase = testTrackmRNADynamics_2015_07_25_P2P_75uW_bi_short;
+%generateExpectedDataForPrefix(exportTest, segmentSpotsMLTest, trackmRNADynamicsTestCase);
 
 % No histone path of traackmRNADynamics is processed separately
-trackmRNADynamicsNotHistoneTestCase = testTrackmRNADynamicsNotHistone_2015_07_25_P2P_75uW_bi_short;
-generateExpectedDataTrackmRNADynamicsNotHistone(trackmRNADynamicsNotHistoneTestCase);
+%trackmRNADynamicsNotHistoneTestCase = testTrackmRNADynamicsNotHistone_2015_07_25_P2P_75uW_bi_short;
+%generateExpectedDataTrackmRNADynamicsNotHistone(trackmRNADynamicsNotHistoneTestCase);
 
 % Segment spots only has one test so far
 segmentSpotsTest = testSegmentSpots_2015_07_25_P2P_75uW_bi_short;


### PR DESCRIPTION
Restructured generate data script to allow running them standalone and avoid issues with Matlab locking folders in server.