### PR TITLE
z-slices padding feature for series with different z-slices count

### DIFF
--- a/src/export/ExportDataForLivemRNA.m
+++ b/src/export/ExportDataForLivemRNA.m
@@ -31,6 +31,8 @@
 % 'skipExtraction': This doesn't extract LIF files to Tifs. Occasionally
 %                   useful if only the FrameInfo is desired. 
 % 'rootFolder': open a directory different from the default user directory
+% 'zslicesPadding': if series have different number of z-slices, pad them
+% with blank images so every generates series has the same amount
 %
 % OUTPUT
 % Exported tif images are placed in the PreProcessedData folder and divided
@@ -65,7 +67,7 @@
 function Prefix = ExportDataForLivemRNA(varargin)
 
   [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest, keepTifs,...
-    generateTifStacks, nuclearGUI, skipExtraction, rootFolder] = exportDataForLivemRNA_processInputParameters(varargin{:});
+    generateTifStacks, nuclearGUI, skipExtraction, rootFolder, zslicesPadding] = exportDataForLivemRNA_processInputParameters(varargin{:});
 
   [rawDataPath, ~, DropboxFolder, ~, PreProcPath, rawDataFolder, Prefix, ExperimentType, Channel1, Channel2, ~,...
     Channel3] = readMovieDatabase(Prefix);
@@ -101,7 +103,7 @@ function Prefix = ExportDataForLivemRNA(varargin)
 
   elseif strcmpi(FileMode, 'LSM')
     FrameInfo = processLSMData(rawDataFolder, D, FrameInfo, ExperimentType, ...
-    Channel1, Channel2, Channel3, ProjectionType,Prefix, OutputFolder,nuclearGUI);
+    Channel1, Channel2, Channel3, ProjectionType,Prefix, OutputFolder,nuclearGUI, zslicesPadding);
 
   elseif strcmpi(FileMode, 'LIFExport')
     FrameInfo = processLIFExportMode(rawDataFolder, ExperimentType, ProjectionType, Channel1, Channel2, Channel3, Prefix, ...

--- a/src/export/LIFExport/processLIFChannel.m
+++ b/src/export/LIFExport/processLIFChannel.m
@@ -1,27 +1,46 @@
-function processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel)
+function processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder,...
+  LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel, zslicesPadding)
   
   experimentType1 = (strcmpi(ExperimentType,'1spot') || strcmp(ExperimentType,'2spot') || strcmp(ExperimentType,'2spot1color')) && channelIndex == coatChannel;
   experimentType2 = strcmpi(ExperimentType,'2spot2color') || strcmpi(ExperimentType, 'inputoutput');
   experimentType3 = strcmpi(ExperimentType, 'input') && sum(channelIndex == inputProteinChannel);
 
-  %Save the blank images at the beginning and end of the stack
+  % if zPadding was indicated in the arguments, we round up to the series
+  % with more z-slices (because we'll pad with blank images the other series)
+  if (zslicesPadding)
+    topZSlice = max(NSlices);
+  else
+    % if no zPadding, we round down to the series with less z-slices
+    topZSlice = min(NSlices);
+  end
+  
+  % Save the blank image at the beginning of the stack
   NameSuffix = ['_ch',iIndex(channelIndex,2)];
   NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(1,2), NameSuffix, '.tif'];
   imwrite(BlankImage, [OutputFolder, filesep, NewName]);
-  NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(min(NSlices)+2, 2), NameSuffix, '.tif'];
-  imwrite(BlankImage, [OutputFolder, filesep, NewName]);
-  %Copy the rest of the images
   
+  %Copy the rest of the images
   if(experimentType1 || experimentType2 || experimentType3)
     slicesCounter = 1;        
     firstImage = (framesIndex-1) * NSlices(seriesIndex) * NChannels + 1 + (channelIndex - 1);
     lastImage = framesIndex * NSlices(seriesIndex) * NChannels;
     for imageIndex = firstImage:NChannels:lastImage
-      if slicesCounter <= min(NSlices)
+      if slicesCounter <= topZSlice
+          % if zPadding, it will process all images (because topZSlice would be max(NSlices)
+          % if no zPadding, it will process images rounding down to the series with least
+          % zSlices, because topZSlice would be min(NSlices)
           NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(slicesCounter + 1, 2), NameSuffix, '.tif'];
           imwrite(LIFImages{seriesIndex}{imageIndex,1}, [OutputFolder, filesep, NewName]);
           slicesCounter = slicesCounter + 1;
       end
     end
   end
+  
+  % Save as many blank images at the end of the stack are needed
+  % (depending on zPadding being active or not)
+  for zPaddingIndex = slicesCounter+1:topZSlice+2
+    NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(zPaddingIndex, 2), NameSuffix, '.tif'];
+    imwrite(BlankImage, [OutputFolder, filesep, NewName]);
+  end
+  
 end

--- a/src/export/LIFExport/processLIFExportMode.m
+++ b/src/export/LIFExport/processLIFExportMode.m
@@ -47,7 +47,9 @@ function FrameInfo = processLIFExportMode(rawDataFolder, ExperimentType, Project
       for seriesIndex = 1:NSeries
         waitbar(seriesIndex/NSeries, waitbarFigure)
         for framesIndex = 1:NFrames(seriesIndex) 
-          processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel);
+          processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex,...
+            NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel,...
+            histoneChannel, ReferenceHist, coatChannel, inputProteinChannel, false); %JP: hardcode false zPadding for now
           numberOfFrames = numberOfFrames + 1;
         end
       end

--- a/src/export/LIFExport/processLIFFrame.m
+++ b/src/export/LIFExport/processLIFFrame.m
@@ -1,6 +1,9 @@
-function processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType, fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel)
+function processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex,...
+  seriesIndex, NChannels, NSlices, ExperimentType, Channel1, Channel2, Channel3, ProjectionType,...
+  fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel, zslicesPadding)
   for channelIndex = 1:NChannels
-    processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder, LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel);
+    processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix, BlankImage, OutputFolder,...
+      LIFImages, framesIndex, seriesIndex, NChannels, NSlices, coatChannel, inputProteinChannel, zslicesPadding);
   end
   %Now copy nuclear tracking images
   if fiducialChannel

--- a/src/export/ZeissConfocalLSM/createZeissFrameInfo.m
+++ b/src/export/ZeissConfocalLSM/createZeissFrameInfo.m
@@ -1,15 +1,24 @@
-function [FrameRange, FrameInfo] = createZeissFrameInfo(LSMIndex, NFrames, NSlices, FrameInfo, LSMMeta, Frame_Times, ValueField)
+function [FrameRange, FrameInfo] = createZeissFrameInfo(LSMIndex, NFrames, NSlices, FrameInfo, LSMMeta, Frame_Times, ValueField, zslicesPadding)
   %Save the information in FrameInfo
   if LSMIndex == 1
     FrameRange = 1:NFrames(LSMIndex);
   else
     FrameRange = (1:NFrames(LSMIndex)) + length(FrameInfo);
   end
+  
+  % if zPadding was indicated in the arguments, we round up to the series
+  % with more z-slices (because we'll pad with blank images the other series)
+  if (zslicesPadding)
+    topZSlice = max(NSlices);
+  else
+    % if no zPadding, we round down to the series with less z-slices
+    topZSlice = min(NSlices);
+  end
 
   for i = FrameRange
     FrameInfo(i).LinesPerFrame = str2double(LSMMeta.getPixelsSizeY(0));
     FrameInfo(i).PixelsPerLine = str2double(LSMMeta.getPixelsSizeX(0));
-    FrameInfo(i).NumberSlices = min(NSlices);
+    FrameInfo(i).NumberSlices = topZSlice;
     FrameInfo(i).FileMode = 'LSMExport';
 
     if ValueField

--- a/src/export/ZeissConfocalLSM/processLSMData.m
+++ b/src/export/ZeissConfocalLSM/processLSMData.m
@@ -1,5 +1,5 @@
 function FrameInfo = processLSMData(Folder, D, FrameInfo, ExperimentType, ...
-    Channel1, Channel2, Channel3, ProjectionType,Prefix, OutputFolder,nuclearGUI)
+    Channel1, Channel2, Channel3, ProjectionType,Prefix, OutputFolder,nuclearGUI, zslicesPadding)
   % What type of experiment do we have?
 
     NSeries = length(D);
@@ -43,7 +43,7 @@ function FrameInfo = processLSMData(Folder, D, FrameInfo, ExperimentType, ...
 
       StartingTime(LSMIndex) = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits);
       [ValueField, Frame_Times] = obtainZeissFrameTimes(LSMMeta, NSlices, LSMIndex, NPlanes, NChannels, StartingTime, Frame_Times);
-      [~, FrameInfo] = createZeissFrameInfo(LSMIndex, NFrames, NSlices, FrameInfo, LSMMeta, Frame_Times, ValueField);
+      [~, FrameInfo] = createZeissFrameInfo(LSMIndex, NFrames, NSlices, FrameInfo, LSMMeta, Frame_Times, ValueField, zslicesPadding);
 
 
     end
@@ -65,7 +65,7 @@ function FrameInfo = processLSMData(Folder, D, FrameInfo, ExperimentType, ...
           processLIFFrame(numberOfFrames, Prefix, BlankImage, OutputFolder,...
               AllLSMImages, framesIndex, seriesIndex, NChannels(1), NSlices, ...
               ExperimentType, Channel1, Channel2, Channel3, ProjectionType, ...
-              fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel);
+              fiducialChannel, histoneChannel, ReferenceHist, coatChannel, inputProteinChannel, zslicesPadding);
           numberOfFrames = numberOfFrames + 1;
         end
     end

--- a/src/export/exportDataForLivemRNA_processInputParameters.m
+++ b/src/export/exportDataForLivemRNA_processInputParameters.m
@@ -1,5 +1,5 @@
 function [Prefix, SkipFrames, ProjectionType, PreferredFileNameForTest,...
-    keepTifs, generateTifStacks, nuclearGUI, skipExtraction, rootFolder]...
+    keepTifs, generateTifStacks, nuclearGUI, skipExtraction, rootFolder, zslicesPadding]...
     ...
     = exportDataForLivemRNA_processInputParameters(varargin)
 
@@ -16,6 +16,7 @@ generateTifStacks = false;
 nuclearGUI = false;
 skipExtraction = false;
 rootFolder = '';
+zslicesPadding = false;
 
 k=1;
 while k<=length(varargin)
@@ -44,6 +45,8 @@ while k<=length(varargin)
         skipExtraction = true;
     elseif strcmpi(varargin{k}, 'rootFolder')
         rootFolder = varargin{k+1};
+    elseif strcmpi(varargin{k}, 'zslicesPadding')
+        zslicesPadding = true;
     else
         if isempty(rootFolder)
             Prefix = varargin{k};


### PR DESCRIPTION
This feature adds as many blank images at the end of the z-stack, so all series have the same amount of z-slices. Default is false, specify 'zslicesPadding' in ExportDataForLivemRNA to enable it.

For now it's only for LSM FileMode, if it works OK, we can enable it also for LIFExport with a one liner I think.