### PR TITLE
fix for zpadding logic in processLIFFrame

### DIFF
--- a/src/export/LIFExport/processLIFChannel.m
+++ b/src/export/LIFExport/processLIFChannel.m
@@ -34,13 +34,13 @@ function processLIFChannel(ExperimentType, channelIndex, numberOfFrames, Prefix,
           slicesCounter = slicesCounter + 1;
       end
     end
+    
+    % Save as many blank images at the end of the stack are needed
+    % (depending on zPadding being active or not)
+    for zPaddingIndex = slicesCounter+1:topZSlice+2
+      NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(zPaddingIndex, 2), NameSuffix, '.tif'];
+      imwrite(BlankImage, [OutputFolder, filesep, NewName]);
+    end
+
   end
-  
-  % Save as many blank images at the end of the stack are needed
-  % (depending on zPadding being active or not)
-  for zPaddingIndex = slicesCounter+1:topZSlice+2
-    NewName = [Prefix, '_', iIndex(numberOfFrames,3), '_z', iIndex(zPaddingIndex, 2), NameSuffix, '.tif'];
-    imwrite(BlankImage, [OutputFolder, filesep, NewName]);
-  end
-  
 end


### PR DESCRIPTION
moved z-padding logic inside the if where slicesCounter is created so it doesn't fail when experimentType is not one of the supported ones