### PR TITLE
fix to installation script

### DIFF
--- a/src/InstallmRNADynamics.m
+++ b/src/InstallmRNADynamics.m
@@ -8,6 +8,8 @@
 function configContents = InstallmRNADynamics(varargin)
   warning('off','MATLAB:MKDIR:DirectoryExists')
 
+  addpath('./utilities');
+
   ensureRightFolder();
   cd('..');
   MRNA_DYNAMICS_PATH = toSafeWindowsString(pwd);


### PR DESCRIPTION
 new utilities folder needs to be in the path before installation, otherwirse cell2csv is not found. After installation this is replaced by the generated startup.m