### PR TITLE
CZI format start date fix

### DIFF
--- a/src/export/ZeissConfocalLSM/getZeissFrameInfo.m
+++ b/src/export/ZeissConfocalLSM/getZeissFrameInfo.m
@@ -6,7 +6,8 @@ function [FrameInfo,AllLSMImages,NSlices, NPlanes, NFrames,Frame_Times,NChannels
     Folder = RawDataFiles(LSMIndex).folder;
     %Load the file using BioFormats
     LSMImages = bfopen([Folder, filesep, RawDataFiles(LSMIndex).name]);
-
+    FileCreationDate = RawDataFiles(LSMIndex).datenum;
+    
     % Extract the metadata for each series
     LSMMeta = LSMImages{:, 4}; % OME Metadata
     LSMMeta2 = LSMImages{:, 2}; % Original Metadata
@@ -37,9 +38,9 @@ function [FrameInfo,AllLSMImages,NSlices, NPlanes, NFrames,Frame_Times,NChannels
     NDigits = getNDigits(NFrames, LSMIndex);
 
     try
-        StartingTime(LSMIndex) = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits);
+        StartingTime(LSMIndex) = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits, FileCreationDate);
     catch
-        StartingTime(LSMIndex) = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits+1);
+        StartingTime(LSMIndex) = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits+1, FileCreationDate);
     end       
     
     % add times

--- a/src/export/ZeissConfocalLSM/obtainZeissStartingTime.m
+++ b/src/export/ZeissConfocalLSM/obtainZeissStartingTime.m
@@ -1,4 +1,4 @@
-function StartingTime = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits)
+function StartingTime = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDigits, FileCreationDate)
   % Get the starting time of this acquisition
   % This is different if I have an LSM or CZI file
   LSMDir = dir([Folder, filesep, '*.lsm']);     %Zeiss confocal, old LSM format
@@ -8,14 +8,18 @@ function StartingTime = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDig
     StartingTime = LSMMeta2.get(['TimeStamp #', iIndex(1, NDigits)]); %SEANCHANGE
   elseif ~isempty(CZIDir)
     TimeStampString = LSMMeta2.get('Global Information|Image|T|StartTime #1');
+
+    %Get the number of days since 1/1/0000
     if isempty(TimeStampString)
         disp('StartTime was not present in CZI metadata. Using file creation date as start date')
-        TimeStampString = '2020-11-26T00:00:00' %JP HARDCODE just for testing
-    TimeStampStrings{LSMIndex} = TimeStampString;
-    %Get the number of days since 1/1/0000
-    TimeStamp = datetime(TimeStampString(1:19),'InputFormat','yyyy-MM-dd''T''HH:mm:ss');
-    %Get the milliseconds, note that we're not using them!
-    MilliSeconds = TimeStamp(21:end-1);
+        % JP we "fake" an experiment start date since CZI does not appear
+        % to have this info, just relative timestamps.
+        % FileCreationDate is a datenum, we need to reformat it
+        % as the code downstream expects it ('2020-11-26T00:00:00')
+        TimeStamp = datetime(FileCreationDate, 'ConvertFrom', 'datenum')
+    else
+        TimeStamp = datetime(TimeStampString(1:19),'InputFormat','yyyy-MM-dd''T''HH:mm:ss');
+    end
     %Convert the time to seconds. We're ignoring the seconds.
     StartingTime = datenum(TimeStamp)*24*60*60; %SEANCHANGE from StartingTime(LSMIndex)
   else


### PR DESCRIPTION
Now we are taking starting date from czi file creation date, as datenum. Cleaned up a little bit.