### PR TITLE
Imaris support for getting csv info from multiple stats files

### DIFF
--- a/src/export/ZeissConfocalLSM/obtainZeissStartingTime.m
+++ b/src/export/ZeissConfocalLSM/obtainZeissStartingTime.m
@@ -11,12 +11,12 @@ function StartingTime = obtainZeissStartingTime(Folder, LSMIndex, LSMMeta2, NDig
 
     %Get the number of days since 1/1/0000
     if isempty(TimeStampString)
-        disp('StartTime was not present in CZI metadata. Using file creation date as start date')
+        disp('StartTime was not present in CZI metadata. Using file creation date as start date');
         % JP we "fake" an experiment start date since CZI does not appear
         % to have this info, just relative timestamps.
         % FileCreationDate is a datenum, we need to reformat it
         % as the code downstream expects it ('2020-11-26T00:00:00')
-        TimeStamp = datetime(FileCreationDate, 'ConvertFrom', 'datenum')
+        TimeStamp = datetime(FileCreationDate, 'ConvertFrom', 'datenum');
     else
         TimeStamp = datetime(TimeStampString(1:19),'InputFormat','yyyy-MM-dd''T''HH:mm:ss');
     end

--- a/src/export/ZeissConfocalLSM/processLSMData.m
+++ b/src/export/ZeissConfocalLSM/processLSMData.m
@@ -28,12 +28,12 @@ function FrameInfo = processLSMData(Folder, RawDataFiles, FrameInfo,...
       
       % save FrameInfo
       liveExperiment = LiveExperiment(Prefix);
-      save([liveExperiment.resultsFolder,filesep,'FrameInfo.mat'], 'FrameInfo')
+      save([liveExperiment.resultsFolder,filesep,'FrameInfo.mat'], 'FrameInfo');
       
       % this function exports tif z stacks
       exportTifStacks(AllLSMImages, 'LSM', NChannels, NFrames, NSlices, Prefix, ...
           moviePrecision, hisPrecision, nuclearGUI, ProjectionType, Channels, ReferenceHist, ...
-          skipNuclearProjection,zslicesPadding)           
+          skipNuclearProjection,zslicesPadding);
       
       % Look for flat field images
       [FFPaths, FFToUse, LSMFF] = findFlatFieldInformation(Folder);
@@ -44,14 +44,21 @@ function FrameInfo = processLSMData(Folder, RawDataFiles, FrameInfo,...
       if isfolder(imarisFolder)
           disp('Imaris results folder detected. Will get nuclear tracking info from Imaris.')
           
+          DropboxFolder = liveExperiment.userResultsFolder;
+          ellipsesFile = [DropboxFolder,filesep,Prefix,filesep,'Ellipses.mat'];
+          schnitzcellsFile = [DropboxFolder,filesep,Prefix,filesep,Prefix,'_lin.mat']; 
+
           imarisStatisticsFolder = [imarisFolder, filesep, liveExperiment.experimentName, '_Statistics'];
           positionsFile = [imarisStatisticsFolder, filesep, liveExperiment.experimentName, '_Position.csv'];
+
+          % multi-file version of imaris data where there's a statistics subfolder with a positions file
+          % for each movie file instead of a single csv file for the whole movie
+          multiFileStats = dir([imarisFolder, filesep, '**/*Out_Position.csv']);
+          
           if isfile(positionsFile)
             disp('Parsing Imaris position file...')
 
-            DropboxFolder = liveExperiment.userResultsFolder;
-            ellipsesFile = [DropboxFolder,filesep,Prefix,filesep,'Ellipses.mat'];
-            schnitzcellsFile = [DropboxFolder,filesep,Prefix,filesep,Prefix,'_lin.mat']; 
+            
 
             % Liz says: The entire image stack is 200 pixels in x, 444 in y and 100 in z (again will change in future datasets).
             % The x and y resolutions is 0.234 microns per pixel and z is 0.5 microns per pixel, but this will change in future datasets.
@@ -66,17 +73,55 @@ function FrameInfo = processLSMData(Folder, RawDataFiles, FrameInfo,...
             % ZStep: 0.5000
             % Time: 1.4797e+04
 
-            [schnitzcells, Ellipses] = readimariscsv(imarisStatisticsFolder, positionsFile, FrameInfo(1).PixelSize, FrameInfo(1).PixelSize, FrameInfo(1).ZStep);
-
+            [schnitzcells, Ellipses] = readimariscsv(0, imarisStatisticsFolder, positionsFile, FrameInfo(1).PixelSize, FrameInfo(1).PixelSize, FrameInfo(1).ZStep);
 
             save2(ellipsesFile, Ellipses); 
             save2(schnitzcellsFile, schnitzcells); 
 
             disp('Saved imaris-based Ellipses and schnitzcells files in DynamicsResults folder.');
+          elseif ~isempty(multiFileStats)
+            disp('Parsing mult-file Imaris statistic data...')
+
+            % because each Imaris file corresponds to a different movie sub-file,
+            % we need to offset frame numbers to match overall frame numbering
+            % for example file 1 contains frames 1 and 2, and file 2 contains also frames 1 and 2,
+            % but for us it's file 1 = frame 1 and 2, file 2 = frames 3 and 4, and we schnitzcells and Ellipses
+            % to reflect that numbering
+            frameNumberOffset = 0;
+            
+            for positionFileIndex = 1:size(multiFileStats)
+              positionSubFile = multiFileStats(positionFileIndex);
+              fprintf('Parsing position file at %s\n', positionSubFile.name);
+              
+              % each csv processing will tell us the last frame number it referenced
+              % so we can use that to offset the frame numbers in next file
+              [partialSchnitzcells, partialEllipses, lastFrame] = readimariscsv(frameNumberOffset, positionSubFile.folder, [positionSubFile.folder, filesep, positionSubFile.name], FrameInfo(1).PixelSize, FrameInfo(1).PixelSize, FrameInfo(1).ZStep);
+
+              % append partial info from schnitcells and ellipses from sub file
+              % to the general structs
+              if (positionFileIndex == 1)
+                % it's the first file, create general variables
+                Ellipses = partialEllipses;
+                schnitzcells = partialSchnitzcells;
+              else
+                % it's not the first file, variables already exist, so we concatenate to them
+                schnitzcells = [schnitzcells; partialSchnitzcells];
+                Ellipses = [Ellipses; partialEllipses];
+              end
+
+              frameNumberOffset = lastFrame;              
+              fprintf('Last frame number was %d\n', frameNumberOffset);
+
+            end
+
+            save2(ellipsesFile, Ellipses); 
+            save2(schnitzcellsFile, schnitzcells); 
+
           else
-            error(['Imaris folder does not contain positions file at ', positionsFile]);
+            error(['Statistics files not found in Imaris folder.', positionsFile]);
           end
           
+
       end
 
       if nuclearGUI

--- a/src/export/ZeissConfocalLSM/readImarisEllipsoidTables.m
+++ b/src/export/ZeissConfocalLSM/readImarisEllipsoidTables.m
@@ -1,9 +1,10 @@
 function [A, B, C] = readImarisEllipsoidTables(imarisStatisticsFolder)
 
-	ellipsoidFilePrefix = 'Ellipsoid_Axis_Length_';
+	ellipsoidFilePrefix = '*Ellipsoid_Axis_Length_';
 
 	function ellipsoidTable = readEllipsoidFile(suffix)
-		ellipsesFilePath = [imarisStatisticsFolder, filesep, ellipsoidFilePrefix, suffix, '.csv'];
+		D = dir([imarisStatisticsFolder, filesep, ellipsoidFilePrefix, suffix, '.csv']);
+	    ellipsesFilePath = [D(1).folder, filesep, D(1).name];
 	    opts = detectImportOptions(ellipsesFilePath);
 	    opts.VariableNamesLine = 3;
 


### PR DESCRIPTION
This is needed for a multiple-file movie, where Imaris stats are splited into multiple csv sub-files.
Note: there's a current limiteation in how Imaris tracks nuclei. Imaris "Tracking session" resets for each sub-file, so its TrackingID resets too. This means it breaks lineage across files, and we end up with a lot of nuclei traces that appear as different but are in fact the same. This limitation is currently undergoing testing.